### PR TITLE
Add Zehn compression as default

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,7 +47,7 @@ all : all-am @EXE_NAME@
 	chmod +x $@
 
 @ZEHN_NAME@ : @ELF_NAME@
-	@NSPIRE_GENZEHN@ --input $^ --output $@ @NSPIRE_ZEHN_FLAGS@
+	@NSPIRE_GENZEHN@ --compress --input $^ --output $@ @NSPIRE_ZEHN_FLAGS@
 	chmod +x $@
 
 clean: clean-am

--- a/src/worldmap.cpp
+++ b/src/worldmap.cpp
@@ -984,7 +984,7 @@ void WorldMap::loadgame(const std::string &filename)
 
 		lisp_free(savegame);
 	DEBUG_DONE();
-}}}
+}
 
 void WorldMap::loadmap(const std::string &filename)
 {


### PR DESCRIPTION
Also fixes superfluous }'s in worldmap.cpp generating lots of weird errors.
supertux.tns is now only ~2MiB large!
